### PR TITLE
Fix checkbox merge issue when last item lacks newline

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -284,6 +284,7 @@ export default class ObsidianCheckboxSort extends Plugin {
 					// If this is the last item, it doesn't have a newline, and the first moved checkbox also doesn't have a newline - add a newline to this line.
 			        if (
 			          i == blockEndLine &&
+					  !itemData.text.endsWith("\n") &&
 			          tickedItemsData.length > 0 &&
 			          !tickedItemsData[0].text.startsWith("\n")
 			        ) {

--- a/main.ts
+++ b/main.ts
@@ -281,6 +281,14 @@ export default class ObsidianCheckboxSort extends Plugin {
                 if (isPeerTickedForSorting) {
                     tickedItemsData.push(itemData);
                 } else {
+					// If this is the last item, it doesn't have a newline, and the first moved checkbox also doesn't have a newline - add a newline to this line.
+			        if (
+			          i == blockEndLine &&
+			          tickedItemsData.length > 0 &&
+			          !tickedItemsData[0].text.startsWith("\n")
+			        ) {
+			          itemData.text += "\n";
+			        }
                     untickedItemsData.push(itemData);
                 }
 


### PR DESCRIPTION
The plugin doesn't account for the fact that the last checkbox item might not end with a newline character, which can cause checkboxes to be merged together when moving them.

For example, given the following list:
```md
- [ ] test  
- [ ] test 2  
- [ ] test 3
```
If you check the `test 2` item, the result becomes:
```md
- [ ] test  
- [ ] test 3- [x] test 2
```
This PR fixes the issue by appending a newline to the last line if it's missing, preventing the checkbox from being merged with the previous line.